### PR TITLE
实现最新的禁漫APP接口加解密算法

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -42,9 +42,9 @@ UpdateUrl3 = "https://hub.fastgit.xyz/tonquer/JMComic-qt/releases/latest"
 UpdateUrl3Api = "https://api.fastgit.xyz/repos/tonquer/JMComic-qt/releases"
 UpdateUrl3Back = "https://hub.fastgit.xyz/tonquer/JMComic-qt"
 
-UpdateVersion = "v1.1.7"
-RealVersion = "v1.1.7"
-VersionTime = "2023-11-3"
+UpdateVersion = "v1.1.8"
+RealVersion = "v1.1.8"
+VersionTime = "2023-11-22"
 
 Waifu2xVersion = "1.1.6"
 LoginUserName = ""

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,4 +8,5 @@ lxml==4.6.4
 pycryptodomex==3.12.0
 Pysocks==1.7.1
 natsort==8.2.0
+jmcomic>=2.4.3
 # pywin32==302

--- a/src/server/req.py
+++ b/src/server/req.py
@@ -117,16 +117,17 @@ class ServerReq(object):
         }
 
     def ParseData(self, data) -> str:
-        param = "{}{}".format(self.now, "18comicAPPContent")
-        key = hashlib.md5(param.encode("utf-8")).hexdigest()
-        aes = AES.new(key.encode("utf-8"), AES.MODE_ECB)
-        byteData = base64.b64decode(data.encode("utf-8"))
-        result = aes.decrypt(byteData)
-        unpad = lambda s: s[0:-s[-1]]
-        result2 = unpad(result)
-        newData = result2.decode()
-        return newData
-
+        # param = "{}{}".format(self.now, "18comicAPPContent")
+        # key = hashlib.md5(param.encode("utf-8")).hexdigest()
+        # aes = AES.new(key.encode("utf-8"), AES.MODE_ECB)
+        # byteData = base64.b64decode(data.encode("utf-8"))
+        # result = aes.decrypt(byteData)
+        # unpad = lambda s: s[0:-s[-1]]
+        # result2 = unpad(result)
+        # newData = result2.decode()
+        # return newData
+        from jmcomic import JmCryptoTool
+        return JmCryptoTool.decode_resp_data(data, ts=self.now)
 
 # 检查更新
 class CheckUpdateReq(ServerReq):


### PR DESCRIPTION
hi！
我通过对apk逆向，实现了禁漫最新的接口加解密算法，并放到了我维护的一个python库中jmcomic 
我尝试在你的项目基础之上，引入我的库代替你原来的ParseData方法，目前可以正常解析了，如下图所示，应该是没有问题了
于是我提了这个PR，不知道你有没有兴趣合并我的代码？


![Snipaste_2023-11-22_18-21-43](https://github.com/tonquer/JMComic-qt/assets/93357912/e1e51cf9-bf43-4aa7-9304-184a314a23a7)
![Snipaste_2023-11-22_18-22-20](https://github.com/tonquer/JMComic-qt/assets/93357912/03b34122-facc-4ae1-9aa3-565b4f1bff7b)
![Snipaste_2023-11-22_18-23-10](https://github.com/tonquer/JMComic-qt/assets/93357912/94e36183-ef70-484a-a40e-26be9631947d)
![Snipaste_2023-11-22_18-21-19](https://github.com/tonquer/JMComic-qt/assets/93357912/541a6a00-276e-4c61-86f0-478ba5048580)
