### PR TITLE
feat: update mobile API domain(GlobalConfig.Url2List)

### DIFF
--- a/src/config/global_config.py
+++ b/src/config/global_config.py
@@ -32,7 +32,7 @@ class GlobalConfig:
 
     # Url2 = GlobalItem("https://www.jmapinode.biz")
     # PicUrl2 = GlobalItem("https://cdn-msp.jmapinodeudzn.net")
-    Url2List = GlobalItem(["https://www.cdn-eldenringproxy.xyz","https://cn-appdata.jmapiproxy2.cc","https://www.jmapinodeudzn.xyz","https://www.jmapinode.xyz"])
+    Url2List = GlobalItem(["https://www.cdnxxx-proxy.xyz","https://www.cdnxxx-proxy.co","https://www.cdnxxx-proxy.vip","https://www.cdnxxx-proxy.org"])
 
     ProxyApiDomain2 = GlobalItem("jm2-api.ggo.icu")
     ProxyImgDomain2 = GlobalItem("jm2-img.ggo.icu")
@@ -41,9 +41,9 @@ class GlobalConfig:
         ["https://cdn-msp.jmapinodeudzn.net", "https://cdn-msp2.jmapinodeudzn.net", "https://cdn-msp.jmapiproxy3.cc",
          "https://cdn-msp.jmapiproxy4.cc"])
 
-    CdnApiUrl = GlobalItem("https://www.jmapinodeudzn.xyz")
+    CdnApiUrl = GlobalItem("https://www.cdnxxx-proxy.vip")
     CdnImgUrl = GlobalItem("https://cdn-msp.jmapiproxy3.cc")
-    ProxyApiUrl = GlobalItem("https://www.jmapinodeudzn.xyz")
+    ProxyApiUrl = GlobalItem("https://www.cdnxxx-proxy.vip")
     ProxyImgUrl = GlobalItem("https://cdn-msp.jmapiproxy3.cc")
     HeaderVer = GlobalItem("1.7.0")
 


### PR DESCRIPTION
JM Comic updated the mobile API domain yesterday, and this PR updates the corresponding domain in the `GlobalConfig` source code.

However, I noticed that `JMComic-qt` fetches `config.txt` from your personal server every time it starts running to initialize `GlobalConfig`. 
Since the `config.txt` on your server hasn't been updated yet, running this PR directly won't show any effect.

When debugging locally, I modify `/src/view/help/help_view.py` and comment out the code related to **fetching `config.txt` from your personal server**, so that I can see the effect of this PR.
It looks like this:
```diff
diff --git a/src/view/help/help_view.py b/src/view/help/help_view.py
index e3a84df..8cd944b 100644
--- a/src/view/help/help_view.py
+++ b/src/view/help/help_view.py
@@ -66,7 +66,8 @@ class HelpView(QWidget, Ui_Help, QtTaskBase):
         Setting.IsPreUpdate.SetValue(int(self.preCheckBox.isChecked()))

     def InitUpdateConfig(self):
-        self.AddHttpTask(req.CheckUpdateConfigReq(), self.InitUpdateConfigBack)
+        # self.AddHttpTask(req.CheckUpdateConfigReq(), self.InitUpdateConfigBack)
+        pass
```

fix this issue #124 