### PR TITLE
fix: resolve 'no attribute index' issue when open downloaded episode

### DIFF
--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -234,6 +234,7 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
                 # else:
                 #     item.setBackground(QColor(0, 0, 0, 0))
                 item.setSizeHint(label.sizeHint() + QSize(20, 20))
+                item.index = i
                 self.listWidget.setItemWidget(item, label)
         return
     # def LoadingPictureComplete(self, data, status):


### PR DESCRIPTION
In the previous code, the `index` was not assigned to the `item` when creating `self.listWidget`. 
This PR resolves the issue by properly assigning the `index` to each item.
fix this issue #123 