### PR TITLE
feat: add XDG base directory support for Linux

### DIFF
--- a/src/component/line_edit/search_line_edit.py
+++ b/src/component/line_edit/search_line_edit.py
@@ -192,7 +192,7 @@ class SearchLineEdit(QLineEdit):
         return
 
     def SaveCacheWord(self):
-        path = os.path.join(Setting.GetConfigPath(), "cache_word")
+        path = os.path.join(Setting.GetCachePath(), "cache_word")
         try:
             if not self.cacheWords:
                 return
@@ -203,7 +203,7 @@ class SearchLineEdit(QLineEdit):
             Log.Error(es)
 
     def LoadCacheWord(self):
-        path = os.path.join(Setting.GetConfigPath(), "cache_word")
+        path = os.path.join(Setting.GetCachePath(), "cache_word")
         try:
             if not os.path.isfile(path):
                 return

--- a/src/config/setting.py
+++ b/src/config/setting.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from config import config
+
 
 class SettingValue:
     def __init__(self, tag, defaultV, isNeedReset, des=None):
@@ -205,6 +207,8 @@ class Setting:
                 setItem.InitValue(value, name)
         from tools.log import Log
         Log.UpdateLoggingLevel()
+        if sys.platform == "linux" and not Setting.SavePath.value:
+            Setting.SavePath.SetValue(Setting.GetDataPath())
         return
 
     @staticmethod
@@ -228,27 +232,43 @@ class Setting:
 
     @staticmethod
     def Init():
-        path = Setting.GetConfigPath()
-        if not os.path.isdir(path):
-            os.mkdir(path)
+        for path in [
+            Setting.GetConfigPath(),
+            Setting.GetDataPath(),
+            Setting.GetCachePath(),
+            Setting.GetStatePath(),
+        ]:
+            os.makedirs(path, exist_ok=True)
         return
 
     @staticmethod
-    def GetConfigPath():
-        import sys
+    def _xdgDir(envName, default, *subdirs):
         if sys.platform == "win32":
             return "data"
-        else:
-            from PySide6.QtCore import QDir
-            homePath = QDir.homePath()
-            projectName = ".jmcomic"
-            return os.path.join(homePath, projectName)
+        base = os.environ.get(envName, os.path.join(os.path.expanduser("~"), default))
+        return os.path.join(base, "jmcomic-qt", *subdirs)
+
+    @staticmethod
+    def GetConfigPath():
+        return Setting._xdgDir("XDG_CONFIG_HOME", ".config")
+
+    @staticmethod
+    def GetDataPath():
+        return Setting._xdgDir("XDG_DATA_HOME", ".local/share")
+
+    @staticmethod
+    def GetCachePath():
+        if sys.platform == "win32":
+            return os.path.join(Setting.SavePath.value, config.CachePathDir)
+        return Setting._xdgDir("XDG_CACHE_HOME", ".cache")
+
+    @staticmethod
+    def GetStatePath():
+        return Setting._xdgDir("XDG_STATE_HOME", ".local/state")
 
     @staticmethod
     def GetLogPath():
-        import sys
         if sys.platform == "win32":
             return "logs"
-        else:
-            return os.path.join(Setting.GetConfigPath(), "logs")
+        return Setting._xdgDir("XDG_STATE_HOME", ".local/state", "logs")
 

--- a/src/config/setting.py
+++ b/src/config/setting.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 
 
@@ -232,19 +231,7 @@ class Setting:
         path = Setting.GetConfigPath()
         if not os.path.isdir(path):
             os.mkdir(path)
-        path2 = Setting.GetLocalHomePath()
-        if not os.path.isdir(path2):
-            os.mkdir(path2)
-        Setting.CheckRepair()
-        Setting.CheckRepairLocalDb()
         return
-
-    @staticmethod
-    def GetLocalHomePath():
-        from PySide6.QtCore import QDir
-        homePath = QDir.homePath()
-        projectName = ".comic-qt"
-        return os.path.join(homePath, projectName)
 
     @staticmethod
     def GetConfigPath():
@@ -265,44 +252,3 @@ class Setting:
         else:
             return os.path.join(Setting.GetConfigPath(), "logs")
 
-    @staticmethod
-    def CheckRepair():
-        if sys.platform != "win32":
-            return
-        try:
-            from PySide6.QtCore import QDir
-            homePath = QDir.homePath()
-            projectName = ".jmcomic"
-            oldPath = os.path.join(homePath, projectName)
-            fileList = ["download.db", "config.ini", "history.db", "cache_word"]
-            for file in fileList:
-                filePath = os.path.join("data", file)
-                if not os.path.isfile(filePath):
-                    oldFilePath = os.path.join(oldPath, file)
-                    if os.path.isfile(oldFilePath):
-                        shutil.move(oldFilePath, filePath)
-        except Exception as es:
-            from tools.log import Log
-            Log.Error(es)
-
-    @staticmethod
-    def CheckRepairLocalDb():
-        try:
-            fileName = os.path.join(Setting.GetLocalHomePath(), "local_read.db")
-            toFileName = os.path.join(Setting.GetConfigPath(), "local_read.db")
-            from config import config
-            copyOkName = os.path.join(Setting.GetLocalHomePath(), "{}_local.ok".format(config.ProjectName))
-            from PySide6.QtCore import QDir
-            if os.path.isfile(copyOkName):
-                return
-            if not os.path.isfile(fileName):
-                return
-            if os.path.isfile(toFileName):
-                return
-            shutil.copy(fileName, copyOkName)
-            shutil.copy(fileName, toFileName)
-            from server import Log
-            Log.Warn("copy local read db")
-        except Exception as es:
-            from tools.log import Log
-            Log.Error(es)

--- a/src/task/qt_task.py
+++ b/src/task/qt_task.py
@@ -90,9 +90,7 @@ class QtTaskBase:
 
         if not cachePath and not savePath:
             if Setting.SavePath.value and path:
-                filePath2 = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), path)
-                cachePath = filePath2
-
+                cachePath = os.path.join(Setting.GetCachePath(), path)
         # if not Setting.IsOpenDohPicture.value:
         return TaskDownload().DownloadTask(url, downloadCallBack, completeCallBack, downloadStCallBack, backParam, loadPath,
                                                cachePath, savePath, saveParam, cleanFlag, isReload, resetCnt)

--- a/src/task/task_download.py
+++ b/src/task/task_download.py
@@ -270,7 +270,7 @@ class TaskDownload(TaskBase, QtTaskBase):
                         return
                 else:
                     path = ToolUtil.GetRealPath(task.index+1, "book/{}/{}".format(task.bookId, task.epsIndex+1))
-                    cachePath2 = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), path)
+                    cachePath2 = os.path.join(Setting.GetCachePath(), path)
                     checkPaths = [task.loadPath]
 
                     if Setting.SavePath.value:

--- a/src/task/task_waifu2x.py
+++ b/src/task/task_waifu2x.py
@@ -208,8 +208,7 @@ class TaskWaifu2x(TaskBase):
         if not noSaveCache and path and Setting.SavePath.value:
             a = crc32(json.dumps(model).encode("utf-8"))
             if Setting.SavePath.value:
-                path2 = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), config.Waifu2xPath)
-                path = os.path.join(path2, path)
+                path = os.path.join(Setting.GetCachePath(), config.Waifu2xPath, path)
                 info.cachePath = path + "-{}".format(a)
 
         if cleanFlag:

--- a/src/view/download/download_db.py
+++ b/src/view/download/download_db.py
@@ -12,7 +12,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 class DownloadDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "download")
-        path = os.path.join(Setting.GetConfigPath(), "download.db")
+        path = os.path.join(Setting.GetStatePath(), "download.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/download/download_dir_view.py
+++ b/src/view/download/download_dir_view.py
@@ -29,8 +29,8 @@ class DownloadDirView(BaseMaskDialog, Ui_DownloadDir, QtTaskBase):
         if url:
             self.lineEdit.setText(url)
             self.downloadDir.setText(os.path.join(url, config.SavePathDir))
-            self.cacheDir.setText(os.path.join(url, config.CachePathDir))
-            self.waifu2xDir.setText(os.path.join(os.path.join(url, config.CachePathDir), config.Waifu2xPath))
+            self.cacheDir.setText(Setting.GetCachePath())
+            self.waifu2xDir.setText(os.path.join(Setting.GetCachePath(), config.Waifu2xPath))
 
     def SavePath(self):
         path = self.lineEdit.text()

--- a/src/view/history/history_view.py
+++ b/src/view/history/history_view.py
@@ -32,7 +32,7 @@ class HistoryView(QtWidgets.QWidget, Ui_History):
         self.bookList.LoadCallBack = self.LoadNextPage
         self.history = {}
         self.db = QSqlDatabase.addDatabase("QSQLITE", "history")
-        path = os.path.join(Setting.GetConfigPath(), "history.db")
+        path = os.path.join(Setting.GetStatePath(), "history.db")
         self.db.setDatabaseName(path)
         # self.bookList.InstallDel()
 

--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -103,8 +103,8 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
             self.localButton.setIcon(QIcon(":/png/icon/icon_like.png"))
         else:
             self.localButton.setIcon(QIcon(":/png/icon/icon_like_off.png"))
-        path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "waifu2x/book/{}".format(self.bookId))
+        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
         if os.path.isdir(path) or os.path.isdir(waifuPath):
             self.clearButton.setIcon(QIcon(":/png/icon/clear_on.png"))
         else:
@@ -379,12 +379,8 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
         self.AddHttpTask(req.AddAndDelFavoritesReq2(self.bookId), self.AddFavoriteBack)
 
     def ClearCache(self):
-
-        path = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                            "book/{}".format(self.bookId))
-        waifuPath = os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir),
-                                 "waifu2x/book/{}".format(self.bookId))
-
+        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
         isClear = QMessageBox.information(self, Str.GetStr(Str.ClearCache), Str.GetStr(Str.ConfirmClearBookCache).format(path, waifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
         if isClear == QtWidgets.QMessageBox.Yes:
             if not Setting.SavePath.value:

--- a/src/view/info/book_info_view.py
+++ b/src/view/info/book_info_view.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import shutil
 from functools import partial
@@ -103,9 +104,9 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
             self.localButton.setIcon(QIcon(":/png/icon/icon_like.png"))
         else:
             self.localButton.setIcon(QIcon(":/png/icon/icon_like_off.png"))
-        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
-        if os.path.isdir(path) or os.path.isdir(waifuPath):
+        path = os.path.join(Setting.GetCachePath(), "cover/{}.*".format(self.bookId))
+        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/cover/{}*".format(self.bookId))
+        if glob.glob(path) or glob.glob(waifuPath):
             self.clearButton.setIcon(QIcon(":/png/icon/clear_on.png"))
         else:
             self.clearButton.setIcon(QIcon(":/png/icon/clear_off.png"))
@@ -379,16 +380,18 @@ class BookInfoView(QtWidgets.QWidget, Ui_BookInfo, QtTaskBase):
         self.AddHttpTask(req.AddAndDelFavoritesReq2(self.bookId), self.AddFavoriteBack)
 
     def ClearCache(self):
-        path = os.path.join(Setting.GetCachePath(), "book/{}".format(self.bookId))
-        waifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/book/{}".format(self.bookId))
-        isClear = QMessageBox.information(self, Str.GetStr(Str.ClearCache), Str.GetStr(Str.ConfirmClearBookCache).format(path, waifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
+        displayPath = os.path.join(Setting.GetCachePath(), "cover/{}".format(self.bookId))
+        displayWaifuPath = os.path.join(Setting.GetCachePath(), "waifu2x/cover/{}".format(self.bookId))
+        path = displayPath + ".*"
+        waifuPath = displayWaifuPath + "*"
+        isClear = QMessageBox.information(self, Str.GetStr(Str.ClearCache), Str.GetStr(Str.ConfirmClearBookCache).format(displayPath, displayWaifuPath), QtWidgets.QMessageBox.Yes|QtWidgets.QMessageBox.No)
         if isClear == QtWidgets.QMessageBox.Yes:
             if not Setting.SavePath.value:
                 return
-            if os.path.isdir(path):
-                shutil.rmtree(path, True)
-            if os.path.isdir(waifuPath):
-                shutil.rmtree(waifuPath, True)
+            for f in glob.glob(path):
+                os.remove(f)
+            for f in glob.glob(waifuPath):
+                os.remove(f)
         self.UpdateFavoriteIcon()
 
     def DelFavoriteBack(self, raw):

--- a/src/view/nas/nas_db.py
+++ b/src/view/nas/nas_db.py
@@ -13,7 +13,7 @@ from view.nas.nas_item import NasUploadItem, NasInfoItem
 class NasDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "nas")
-        path = os.path.join(Setting.GetConfigPath(), "nas.db")
+        path = os.path.join(Setting.GetStatePath(), "nas.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/nas/nas_item.py
+++ b/src/view/nas/nas_item.py
@@ -162,7 +162,7 @@ class NasUploadItem(QtTaskBase):
         if nasInfo.is_waifu2x:
             srcDir = os.path.join(downloadInfo.convertPath, ToolUtil.GetCanSaveName(epsInfo.epsTitle))
 
-        desPath = os.path.join(os.path.join(os.path.join(Setting.SavePath.value, config.CachePathDir), "zip"), ToolUtil.GetCanSaveName(downloadInfo.title))
+        desPath = os.path.join(os.path.join(Setting.GetCachePath(), "zip"), ToolUtil.GetCanSaveName(downloadInfo.title))
 
         if self.curPreUpIndex == 0:
             desFile = os.path.join(desPath, "{}.zip".format(ToolUtil.GetCanSaveName(downloadInfo.title)))

--- a/src/view/setting/setting_view.py
+++ b/src/view/setting/setting_view.py
@@ -473,8 +473,8 @@ class SettingView(QtWidgets.QWidget, Ui_SettingNew):
         if not url:
             url = "./"
         self.downloadDir.setText(os.path.join(url, config.SavePathDir))
-        self.cacheDir.setText(os.path.join(url, config.CachePathDir))
-        self.waifu2xDir.setText(os.path.join(os.path.join(url, config.CachePathDir), config.Waifu2xPath))
+        self.cacheDir.setText(Setting.GetCachePath())
+        self.waifu2xDir.setText(os.path.join(Setting.GetCachePath(), config.Waifu2xPath))
 
     def OpenDir(self, label):
         QDesktopServices.openUrl(QUrl.fromLocalFile(label.text()))

--- a/src/view/tool/batch_sr_tool_db.py
+++ b/src/view/tool/batch_sr_tool_db.py
@@ -11,7 +11,7 @@ from tools.log import Log
 class BatchSrToolDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "batch_sr_tool")
-        path = os.path.join(Setting.GetConfigPath(), "batch_sr_tool.db")
+        path = os.path.join(Setting.GetStatePath(), "batch_sr_tool.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())

--- a/src/view/tool/local_read_db.py
+++ b/src/view/tool/local_read_db.py
@@ -11,7 +11,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 
 class LocalReadDb(object):
     def __init__(self):
-        self.db = sqlite3.connect(os.path.join(Setting.GetConfigPath(), "local_read.db"), check_same_thread=False)
+        self.db = sqlite3.connect(os.path.join(Setting.GetStatePath(), "local_read.db"), check_same_thread=False)
         self.cur = self.db.cursor()
 
         sql = """\

--- a/src/view/user/local_favorite_db.py
+++ b/src/view/user/local_favorite_db.py
@@ -14,7 +14,7 @@ from view.download.download_item import DownloadItem, DownloadEpsItem
 class LocalFavoriteDb(object):
     def __init__(self):
         self.db = QSqlDatabase.addDatabase("QSQLITE", "favorite")
-        path = os.path.join(Setting.GetConfigPath(), "favorite.db")
+        path = os.path.join(Setting.GetStatePath(), "favorite.db")
         self.db.setDatabaseName(path)
         if not self.db.open():
             Log.Warn(self.db.lastError().text())


### PR DESCRIPTION
大佬好，感谢项目，我又来献上Linux端遵循[XDG目录](https://wiki.archlinux.org/title/XDG_Base_Directory)的重构，已在NixOS测试完毕。

主要变更基本与[picacg-qt](https://github.com/tonquer/picacg-qt/pull/417)项目一致：
- 删除过时的迁移代码，避免在HOME直接创建点目录
- 按照XDG目录规则组织项目创建文件，修复前端目录展示
- 修改仅对Linux端生效，Windows端仍为原逻辑

此外，还顺手修复了漫画详情页中清理按钮的逻辑：
现在缓存中存在封面时，能正常高亮并正确清理对应封面/超分封面。
稍后会将该修复同步给picacg-qt，可以的话也请一同合并。

```
~/.config/jmcomic-qt/                      # XDG_CONFIG_HOME
  └── config.ini

~/.local/share/jmcomic-qt/                 # XDG_DATA_HOME（SavePath默认值）
  └── commies/

~/.cache/jmcomic-qt/                       # XDG_CACHE_HOME
  ├── cover/                               # 真实缓存目录为cover，但源代码清除目录为book，已修复
  ├── waifu2x/
  │   └── cover/                           # 问题同上
  ├── zip/
  └── cache_word

~/.local/state/jmcomic-qt/                 # XDG_STATE_HOME
  ├── logs/
  ├── convert.db
  ├── download.db
  ├── nas.db
  ├── history.db
  ├── local_read.db
  └── batch_sr_tool.db
```

以上，祝好。